### PR TITLE
Manual ordering

### DIFF
--- a/onegov/people/collections/memberships.py
+++ b/onegov/people/collections/memberships.py
@@ -17,6 +17,10 @@ class AgencyMembershipCollection(GenericCollection):
     def model_class(self):
         return AgencyMembership
 
+    def by_id(self, id):
+        return super(AgencyMembershipCollection, self).query().filter(
+            self.primary_key == id).first()
+
     def query(self, order_by=None):
         query = super(AgencyMembershipCollection, self).query()
         if not order_by:

--- a/onegov/people/collections/memberships.py
+++ b/onegov/people/collections/memberships.py
@@ -24,9 +24,8 @@ class AgencyMembershipCollection(GenericCollection):
     def query(self, order_by=None):
         query = super(AgencyMembershipCollection, self).query()
         if not order_by:
-            assert False
-        else:
-            assert hasattr(self.model_class, order_by)
+            return query
+        assert hasattr(self.model_class, order_by)
         return query.order_by(getattr(self.model_class, order_by))
 
     def move(self, subject, target, direction, move_on_col):

--- a/onegov/people/collections/memberships.py
+++ b/onegov/people/collections/memberships.py
@@ -19,7 +19,7 @@ class AgencyMembershipCollection(GenericCollection):
 
     def query(self):
         query = super(AgencyMembershipCollection, self).query()
-        return query.order_by(self.model_class.order)
+        return query.order_by(self.model_class.order_within_agency)
 
     def move(self, subject, target, direction):
         """ Takes the given subject and moves it somehwere in relation to the
@@ -62,4 +62,4 @@ class AgencyMembershipCollection(GenericCollection):
                 yield sibling
 
         for order, sibling in enumerate(new_order()):
-            sibling.order = order
+            sibling.order_within_agency = order

--- a/onegov/people/collections/memberships.py
+++ b/onegov/people/collections/memberships.py
@@ -55,7 +55,10 @@ class AgencyMembershipCollection(GenericCollection):
         assert hasattr(subject, move_on_col)
         assert hasattr(target, move_on_col)
 
-        siblings = target.siblings.all()
+        if move_on_col == 'order_within_person':
+            siblings = target.siblings_for_person.all()
+        else:
+            siblings = target.siblings.all()
 
         def new_order():
             for sibling in siblings:

--- a/onegov/people/collections/memberships.py
+++ b/onegov/people/collections/memberships.py
@@ -1,5 +1,5 @@
 from onegov.core.collection import GenericCollection
-from onegov.core.orm.abstract import MoveDirection, AdjacencyListCollection
+from onegov.core.orm.abstract import MoveDirection
 from onegov.people.models import AgencyMembership
 
 

--- a/onegov/people/models/agency.py
+++ b/onegov/people/models/agency.py
@@ -83,13 +83,13 @@ class Agency(AdjacencyList, ContentMixin, TimestampMixin, ORMSearchable):
             AgencyMembership(
                 person_id=person_id,
                 title=title,
-                order=order,
+                order_within_agency=order,
                 **kwargs
             )
         )
 
         for order, membership in enumerate(self.memberships):
-            membership.order = order
+            membership.order_within_agency = order
 
     def sort_children(self, sortkey=None):
         """ Sorts the suborganizations.
@@ -117,4 +117,4 @@ class Agency(AdjacencyList, ContentMixin, TimestampMixin, ORMSearchable):
         sortkey = sortkey or default_sortkey
         memberships = sorted(self.memberships.all(), key=sortkey)
         for order, membership in enumerate(memberships):
-            membership.order = order
+            membership.order_within_agency = order

--- a/onegov/people/models/membership.py
+++ b/onegov/people/models/membership.py
@@ -51,7 +51,7 @@ class AgencyMembership(Base, ContentMixin, TimestampMixin, ORMSearchable):
             'memberships',
             cascade='all, delete-orphan',
             lazy='dynamic',
-            order_by='AgencyMembership.order'
+            order_by='AgencyMembership.order_within_agency'
         )
     )
 
@@ -69,7 +69,10 @@ class AgencyMembership(Base, ContentMixin, TimestampMixin, ORMSearchable):
     )
 
     #: the position of the membership within the agency
-    order = Column(Integer, nullable=False)
+    order_within_agency = Column(Integer, nullable=False)
+
+    #: the position of the membership within all memberships of a person
+    # order_within_person = Column(Integer, nullable=False)
 
     #: describes the membership
     title = Column(Text, nullable=False)
@@ -84,7 +87,7 @@ class AgencyMembership(Base, ContentMixin, TimestampMixin, ORMSearchable):
 
         """
         query = object_session(self).query(self.__class__)
-        query = query.order_by(self.__class__.order)
+        query = query.order_by(self.__class__.order_within_agency)
         query = query.filter(self.__class__.agency == self.agency)
         return query
 

--- a/onegov/people/models/membership.py
+++ b/onegov/people/models/membership.py
@@ -83,11 +83,20 @@ class AgencyMembership(Base, ContentMixin, TimestampMixin, ORMSearchable):
     @property
     def siblings(self):
         """ Returns a query that includes all siblings, including the item
-        itself.
-
+        itself ordered by `order_within_agency`.
         """
         query = object_session(self).query(self.__class__)
         query = query.order_by(self.__class__.order_within_agency)
+        query = query.filter(self.__class__.agency == self.agency)
+        return query
+
+    @property
+    def siblings_for_person(self):
+        """ Returns a query that includes all siblings, including the item
+        itself ordered by `order_within_person`.
+        """
+        query = object_session(self).query(self.__class__)
+        query = query.order_by(self.__class__.order_within_person)
         query = query.filter(self.__class__.agency == self.agency)
         return query
 

--- a/onegov/people/models/membership.py
+++ b/onegov/people/models/membership.py
@@ -72,7 +72,7 @@ class AgencyMembership(Base, ContentMixin, TimestampMixin, ORMSearchable):
     order_within_agency = Column(Integer, nullable=False)
 
     #: the position of the membership within all memberships of a person
-    # order_within_person = Column(Integer, nullable=False)
+    order_within_person = Column(Integer, nullable=False)
 
     #: describes the membership
     title = Column(Text, nullable=False)

--- a/onegov/people/models/person.py
+++ b/onegov/people/models/person.py
@@ -201,6 +201,6 @@ class Person(Base, ContentMixin, TimestampMixin, ORMSearchable):
         """ Returns the memberships sorted alphabetically by the agency. """
 
         def sortkey(membership):
-            return membership.agency.title
+            return membership.order_within_person
 
         return sorted(self.memberships, key=sortkey)

--- a/onegov/people/tests/test_collections.py
+++ b/onegov/people/tests/test_collections.py
@@ -55,13 +55,13 @@ def test_memberships(session):
         title="Member",
         agency_id=agency.id,
         person_id=tom.id,
-        order=2
+        order_within_agency=2
     )
     memberships.add(
         title="Director",
         agency_id=agency.id,
         person_id=tom.id,
-        order=1
+        order_within_agency=1
     )
 
     assert [m.title for m in memberships.query()] == ["Director", "Member"]
@@ -79,19 +79,19 @@ def test_memberships_move(session):
         title="A",
         agency_id=agency.id,
         person_id=person.id,
-        order=1
+        order_within_agency=1
     )
     membership_b = memberships.add(
         title="B",
         agency_id=agency.id,
         person_id=person.id,
-        order=2
+        order_within_agency=2
     )
     membership_c = memberships.add(
         title="C",
         agency_id=agency.id,
         person_id=person.id,
-        order=3
+        order_within_agency=3
     )
 
     assert [m.title for m in memberships.query()] == ['A', 'B', 'C']

--- a/onegov/people/tests/test_models.py
+++ b/onegov/people/tests/test_models.py
@@ -241,7 +241,7 @@ def test_agency_add_person(session):
     agency.add_person(selma.id, "Staff", since="2012")
     agency.add_person(str(selma.id), "Managing director", since="2018")
 
-    assert [m.order for m in agency.memberships] == [0, 1, 2]
+    assert [m.order_within_agency for m in agency.memberships] == [0, 1, 2]
 
     people = [f"{m.title} {m.person.first_name}" for m in agency.memberships]
     assert people == ['Staff Patty', 'Staff Selma', 'Managing director Selma']
@@ -311,7 +311,7 @@ def test_agency_sort_memberships(session):
         session.add(
             AgencyMembership(
                 title="Member",
-                order=order,
+                order_within_agency=order,
                 since="2012",
                 agency_id=agency.id,
                 person_id=person.id
@@ -342,7 +342,7 @@ def test_membership(session):
     session.add(
         AgencyMembership(
             title="Director",
-            order=12,
+            order_within_agency=12,
             since="2012",
             agency_id=agency.id,
             person_id=person.id
@@ -352,7 +352,7 @@ def test_membership(session):
     membership = session.query(AgencyMembership).one()
 
     assert membership.title == "Director"
-    assert membership.order == 12
+    assert membership.order_within_agency == 12
     assert membership.since == "2012"
     assert membership.agency_id == agency.id
     assert membership.person_id == person.id
@@ -386,7 +386,7 @@ def test_membership_polymorphism(session):
             title='default',
             agency_id=agency.id,
             person_id=person.id,
-            order=0
+            order_within_agency=0
         )
     )
     session.add(
@@ -394,7 +394,7 @@ def test_membership_polymorphism(session):
             title='my',
             agency_id=agency.id,
             person_id=person.id,
-            order=1
+            order_within_agency=1
         )
     )
     session.add(
@@ -402,7 +402,7 @@ def test_membership_polymorphism(session):
             title='other',
             agency_id=agency.id,
             person_id=person.id,
-            order=2
+            order_within_agency=2
         )
     )
     session.flush()
@@ -423,19 +423,19 @@ def test_membership_siblings(session):
 
     membership_x = AgencyMembership(
         title="X",
-        order=1,
+        order_within_agency=1,
         agency_id=agency_a.id,
         person_id=person.id
     )
     membership_y = AgencyMembership(
         title="Y",
-        order=2,
+        order_within_agency=2,
         agency_id=agency_a.id,
         person_id=person.id
     )
     membership_z = AgencyMembership(
         title="Z",
-        order=3,
+        order_within_agency=3,
         agency_id=agency_b.id,
         person_id=person.id
     )

--- a/onegov/people/tests/test_models.py
+++ b/onegov/people/tests/test_models.py
@@ -54,6 +54,7 @@ def test_person(session):
 
 
 def test_vcard(session):
+    agency = Agency(name="agency", title="Agency")
     person = Person(
         salutation="Mr.",
         academic_title="Dr.",
@@ -69,11 +70,10 @@ def test_vcard(session):
         notes="Has bad vision.",
     )
     session.add(person)
+    session.add(agency)
     session.flush()
 
-    agency = Agency(name="agency", title="Agency")
     agency.add_person(person.id, "Membership")
-    session.add(agency)
     session.flush()
 
     vcard = person.vcard()
@@ -155,7 +155,7 @@ def test_person_membership_by_agency(session):
 
     person = session.query(Person).one()
     assert [m.title for m in person.memberships_by_agency] == [
-        'n', 'l', 'm', 'o'
+        'l', 'm', 'n', 'o'
     ]
 
 
@@ -312,6 +312,7 @@ def test_agency_sort_memberships(session):
             AgencyMembership(
                 title="Member",
                 order_within_agency=order,
+                order_within_person=0,
                 since="2012",
                 agency_id=agency.id,
                 person_id=person.id
@@ -332,7 +333,7 @@ def test_agency_sort_memberships(session):
     ]
 
 
-def test_membership(session):
+def test_membership_1(session):
     agency = Agency(title='agency', name='agency')
     person = Person(first_name='a', last_name='person')
     session.add(agency)
@@ -343,6 +344,7 @@ def test_membership(session):
         AgencyMembership(
             title="Director",
             order_within_agency=12,
+            order_within_person=0,
             since="2012",
             agency_id=agency.id,
             person_id=person.id
@@ -386,7 +388,8 @@ def test_membership_polymorphism(session):
             title='default',
             agency_id=agency.id,
             person_id=person.id,
-            order_within_agency=0
+            order_within_agency=0,
+            order_within_person=0,
         )
     )
     session.add(
@@ -394,7 +397,8 @@ def test_membership_polymorphism(session):
             title='my',
             agency_id=agency.id,
             person_id=person.id,
-            order_within_agency=1
+            order_within_agency=1,
+            order_within_person=1,
         )
     )
     session.add(
@@ -402,7 +406,8 @@ def test_membership_polymorphism(session):
             title='other',
             agency_id=agency.id,
             person_id=person.id,
-            order_within_agency=2
+            order_within_agency=2,
+            order_within_person=2,
         )
     )
     session.flush()
@@ -424,18 +429,21 @@ def test_membership_siblings(session):
     membership_x = AgencyMembership(
         title="X",
         order_within_agency=1,
+        order_within_person=0,
         agency_id=agency_a.id,
         person_id=person.id
     )
     membership_y = AgencyMembership(
         title="Y",
         order_within_agency=2,
+        order_within_person=1,
         agency_id=agency_a.id,
         person_id=person.id
     )
     membership_z = AgencyMembership(
         title="Z",
         order_within_agency=3,
+        order_within_person=2,
         agency_id=agency_b.id,
         person_id=person.id
     )

--- a/onegov/people/upgrade.py
+++ b/onegov/people/upgrade.py
@@ -89,8 +89,8 @@ def add_parliamentary_group_column(context):
 @upgrade_task('Rename order to order_within_agency')
 def rename_order(context):
     context.operations.alter_column(
-            'agency_memberships', 'order',
-            new_column_name='order_within_agency')
+        'agency_memberships', 'order',
+        new_column_name='order_within_agency')
 
 
 @upgrade_task('Adding order_within_person column')

--- a/onegov/people/upgrade.py
+++ b/onegov/people/upgrade.py
@@ -82,3 +82,31 @@ def add_parliamentary_group_column(context):
             'people',
             Column('parliamentary_group', Text, nullable=True)
         )
+
+
+@upgrade_task('Rename order to order_within_agency')
+def rename_order(context):
+    context.operations.alter_column(
+            'agency_memberships', 'order',
+            new_column_name='order_within_agency')
+
+
+# @upgrade_task('Add AgencyMembership order_for_person column')
+# def add_order_for_person_column(context):
+#     from onegov.core.utils import normalize_for_url
+#     if not context.has_column('agency_memberships', 'order_withing_person'):
+#         context.operations.add_column(
+#             'agency_memberships',
+#             Column('order_within_person', Integer, nullable=False)
+#         )
+#
+#         # Add the integer position based on alphabetic order
+#         def sortkey(membership):
+#             return normalize_for_url(membership.agency.title)
+#
+#         for person in context.app.session().query(Person):
+#             memberships = person.memberships()
+#             memberships_sorted = sorted(person.memberships(), key=sortkey)
+#             ordering = [memberships_sorted.index(el) for el in memberships]
+#             for order, membership in zip(ordering, memberships):
+#                 membership.order_for_person = order

--- a/onegov/people/upgrade.py
+++ b/onegov/people/upgrade.py
@@ -105,7 +105,6 @@ def add_order_within_person_column(context):
     def groupkey(result):
         return result[0].person_id
 
-
     agency_list = []
     for result in session.query(
             AgencyMembership.id,

--- a/onegov/people/upgrade.py
+++ b/onegov/people/upgrade.py
@@ -2,9 +2,10 @@
 upgraded on the server. See :class:`onegov.core.upgrade.upgrade_task`.
 
 """
+import itertools
 from onegov.core.orm.types import JSON
 from onegov.core.upgrade import upgrade_task
-from onegov.people import Person
+from onegov.people import AgencyMembership
 from sqlalchemy import Column, Integer
 from sqlalchemy import Text
 
@@ -91,22 +92,45 @@ def rename_order(context):
             'agency_memberships', 'order',
             new_column_name='order_within_agency')
 
+# @upgrade_task('Kill it 1')
+# def kill_it_temporarely(context):
+#     if context.has_column('agency_memberships', 'order_withing_person'):
+#             context.operations.drop_column(
+#                 'agency_memberships', 'order_withing_person')
 
-@upgrade_task('Add AgencyMembership order_for_person column')
-def add_order_for_person_column(context):
+
+@upgrade_task('Adding order_within_person column')
+def add_order_within_person_column(context):
     from onegov.core.utils import normalize_for_url
+
+    # Add the integer position based on alphabetic order
+    def sortkey(result):
+        return normalize_for_url(result.title)
+
+    def groupkey(result):
+        return result.person_id
+
+    data_list = []
+    for result in context.app.session().query(
+            AgencyMembership.id,
+            AgencyMembership.person_id,
+            AgencyMembership.title
+    ):
+        data_list.append(result)
+
+    index_mapping = {}
+    for person_id, memberships in itertools.groupby(
+            data_list, key=groupkey):
+        s_m = sorted(memberships, key=sortkey)
+        for ix, membership in enumerate(s_m):
+            index_mapping[membership.id] = ix
+
+    def get_index(agency_membership):
+        return index_mapping[agency_membership.id]
+
     if not context.has_column('agency_memberships', 'order_withing_person'):
         context.add_column_with_defaults(
             'agency_memberships',
             Column('order_within_person', Integer, nullable=False),
-            default=0
+            default=get_index
         )
-
-        # Add the integer position based on alphabetic order
-        def sortkey(membership):
-            return normalize_for_url(membership.agency.title)
-
-        for person in context.app.session().query(Person):
-            memberships = sorted(person.memberships, key=sortkey)
-            for ix, membership in enumerate(memberships):
-                membership.order_for_person = ix


### PR DESCRIPTION
Adds another column `order_within_person` to the model `AgencyMembership`. Previous column `order` did not tell if the order is for Person (FK) or for Agency (other FK) and was renamed to `order_within_agency`